### PR TITLE
Include webpack modules in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1"
+    "babel-preset-react": "^6.24.1",
+    "html-webpack-plugin": "^2.28.0",
+    "webpack": "^2.5.1",
+    "webpack-dev-server": "^2.4.5"
   }
 }


### PR DESCRIPTION
App won't compile on systems that don't have the modules installed globally, even after `npm install` command is run.